### PR TITLE
Update Requirements.md

### DIFF
--- a/_docs/Requirements.md
+++ b/_docs/Requirements.md
@@ -52,3 +52,4 @@
 ### Questions
 
 1. Can *NightBook* be used by the NPOI operators at all?
+   


### PR DESCRIPTION
Answer Question #1:
(NPOI operators use the "obslog" system for logging activity throughout the night). It may be possible
 to integrate the nightly obslog in to the "NightBook" log but I am uncertain of the motivation for doing so.